### PR TITLE
Update node version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: 'Node.js dependency freshness via libyear'
 description: 'Track NPM dependency freshness'
 author: 'Sam Lanning <sam@samlanning.com>'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main/index.js'
 branding:
   icon: 'bar-chart-2'


### PR DESCRIPTION
Fixes #17

As described in https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/, actions now need to run with `node16` instead of `node12`